### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push_script_leaves_inquiry_form.yaml
+++ b/.github/workflows/push_script_leaves_inquiry_form.yaml
@@ -1,4 +1,6 @@
 name: 'Push Script - Leaves Inquiry Form'
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/marcobeles20/fsgc-leaves-tracker-and-inquiry/security/code-scanning/1](https://github.com/marcobeles20/fsgc-leaves-tracker-and-inquiry/security/code-scanning/1)

To fix the problem, we should add a `permissions` block at either the workflow root or at the job level, specifying the minimal set of permissions required by this workflow. In general, unless there are steps that need to write to the repository, we should start with `contents: read`, which provides read-only access to repository contents. Since the workflow uses `actions/checkout` and the `clasp-action`, but does not appear to need write access to the repo or create issues/pull requests, `contents: read` is sufficient. The best location is at the workflow root, to apply to all jobs unless overridden. This involves adding the following block below the `name:` key (line 2), shifting subsequent lines down:

```yaml
permissions:
  contents: read
```

No other methods, imports, or changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
