### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push_script_leave_request_form.yaml
+++ b/.github/workflows/push_script_leave_request_form.yaml
@@ -1,4 +1,6 @@
 name: 'Push Script - Leave Request Form'
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/marcobeles20/fsgc-leaves-tracker-and-inquiry/security/code-scanning/3](https://github.com/marcobeles20/fsgc-leaves-tracker-and-inquiry/security/code-scanning/3)

To fix the problem, set the permissions of the workflow explicitly to follow least privilege principle. The best way is to add a `permissions` key at the top level of the workflow YAML file, setting it to `contents: read`, unless more privilege is required. This should be placed directly below the `name:` field, before the `on:` block, affecting all jobs in the workflow (unless any job needs custom permissions). No methods, imports, or other definitions are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
