### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/yaml_lint.yaml
+++ b/.github/workflows/yaml_lint.yaml
@@ -1,4 +1,6 @@
 name: 'YAML Lint'
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/marcobeles20/fsgc-leaves-tracker-and-inquiry/security/code-scanning/2](https://github.com/marcobeles20/fsgc-leaves-tracker-and-inquiry/security/code-scanning/2)

To fix the issue, we must add an explicit `permissions:` key specifying least privilege needed for the workflow. Since the workflow solely performs linting and code checkout, it only requires read access to repository contents. The fix is to add a top-level `permissions:` block:

- Add the following immediately after the workflow `name` (line 1) and before `on:` (line 3):
  ```yaml
  permissions:
    contents: read
  ```
- This ensures that the workflow jobs only have read access to repository contents, following the principle of least privilege.
- No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
